### PR TITLE
do not require OpenMP on apple clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,22 @@ project(lib VERSION 1.0
         DESCRIPTION "Search engine core library"
         LANGUAGES CXX)
 
-find_package(OpenMP REQUIRED)
+# Check if we're not using Apple Clang on macOS
+# since it is not well supported on Apple Clang and causes issues.
+execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version OUTPUT_VARIABLE COMPILER_VERSION)
+if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND COMPILER_VERSION MATCHES "Apple" AND CMAKE_SYSTEM_NAME MATCHES "Darwin"))
+    find_package(OpenMP REQUIRED)
+    if(OpenMP_CXX_FOUND)
+        message(STATUS "Found OpenMP: ${OpenMP_CXX_FLAGS}")
+    endif()
+else()
+    # Define an empty INTERFACE target (no actual linking)
+    if(NOT TARGET OpenMP::OpenMP_CXX)
+        add_library(OpenMP::OpenMP_CXX INTERFACE IMPORTED)
+    endif()
+    
+    message(STATUS "Skipping OpenMP for AppleClang on macOS")
+endif()
 find_package(OpenSSL REQUIRED)
 
 # Create main library target


### PR DESCRIPTION
note: apple clang does not have good support for openmp. to let people use apple clang for now this is added to prevent cmake breaking